### PR TITLE
Send client-side errors to Telegram

### DIFF
--- a/src/Blockcore.AtomicSwaps/Client/Logging/ClientLoggerProvider.cs
+++ b/src/Blockcore.AtomicSwaps/Client/Logging/ClientLoggerProvider.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Blockcore.AtomicSwaps.Client.Logging
+{
+    public class ClientLoggerProvider : ILoggerProvider
+    {
+        private readonly HttpClient _httpClient;
+        private readonly WebApiLoggerOptions _options;
+        private readonly NavigationManager _navigationManager;
+
+        public ClientLoggerProvider(
+                IServiceProvider serviceProvider,
+                IOptions<WebApiLoggerOptions> options,
+                NavigationManager navigationManager)
+        {
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _httpClient = serviceProvider.CreateScope().ServiceProvider.GetRequiredService<HttpClient>();
+            _options = options.Value;
+            _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new WebApiLogger(_httpClient, _options, _navigationManager);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Blockcore.AtomicSwaps/Client/Logging/ClientLoggerProviderExtensions.cs
+++ b/src/Blockcore.AtomicSwaps/Client/Logging/ClientLoggerProviderExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Blockcore.AtomicSwaps.Client.Logging
+{
+    public static class ClientLoggerProviderExtensions
+    {
+        public static ILoggingBuilder AddWebApiLogger(this ILoggingBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services.AddSingleton<ILoggerProvider, ClientLoggerProvider>();
+            return builder;
+        }
+    }
+}

--- a/src/Blockcore.AtomicSwaps/Client/Logging/WebApiLogger.cs
+++ b/src/Blockcore.AtomicSwaps/Client/Logging/WebApiLogger.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Blockcore.AtomicSwaps.Shared;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+
+namespace Blockcore.AtomicSwaps.Client.Logging
+{
+    public class WebApiLogger : ILogger
+    {
+        private readonly WebApiLoggerOptions _options;
+        private readonly HttpClient _httpClient;
+        private readonly NavigationManager _navigationManager;
+
+        public WebApiLogger(HttpClient httpClient, WebApiLoggerOptions options, NavigationManager navigationManager)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => default;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= _options.LogLevel;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            if (formatter is null)
+            {
+                throw new ArgumentNullException(nameof(formatter));
+            }
+
+            try
+            {
+                ClientLog log = new()
+                {
+                    LogLevel = logLevel,
+                    EventId = eventId,
+                    Message = formatter(state, exception),
+                    Exception = exception?.Message,
+                    StackTrace = exception?.StackTrace,
+                    Url = _navigationManager.Uri
+                };
+              _httpClient.PostAsJsonAsync(_options.LoggerEndpointUrl, log);
+
+            }
+            catch(Exception ex)
+            {
+                // don't throw exceptions from the logger
+            }
+        }
+    }
+}

--- a/src/Blockcore.AtomicSwaps/Client/Logging/WebApiLoggerOptions.cs
+++ b/src/Blockcore.AtomicSwaps/Client/Logging/WebApiLoggerOptions.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Logging;
+
+namespace Blockcore.AtomicSwaps.Client.Logging
+{
+    public class WebApiLoggerOptions
+    {
+        public string LoggerEndpointUrl { set; get; }
+
+        public LogLevel LogLevel { get; set; } = LogLevel.Information;
+    }
+}

--- a/src/Blockcore.AtomicSwaps/Client/Program.cs
+++ b/src/Blockcore.AtomicSwaps/Client/Program.cs
@@ -1,5 +1,6 @@
 using Blazored.LocalStorage;
 using Blockcore.AtomicSwaps.Client;
+using Blockcore.AtomicSwaps.Client.Logging;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
@@ -8,6 +9,12 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+builder.Services.Configure<WebApiLoggerOptions>(options => builder.Configuration.GetSection("WebApiLogger").Bind(options));
+builder.Services.AddLogging(configure =>
+{
+    configure.AddWebApiLogger();
+});
 builder.Services.AddSingleton(sp => new GlobalData ());
 
 builder.Services.AddScoped<Storage>();

--- a/src/Blockcore.AtomicSwaps/Client/wwwroot/appsettings.json
+++ b/src/Blockcore.AtomicSwaps/Client/wwwroot/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "WebApiLogger": {
+    "LogLevel": "Warning",
+    "LoggerEndpointUrl": "/api/logs"
+  }
+}

--- a/src/Blockcore.AtomicSwaps/Server/Blockcore.AtomicSwaps.Server.csproj
+++ b/src/Blockcore.AtomicSwaps/Server/Blockcore.AtomicSwaps.Server.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Telegram.Bot" Version="18.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blockcore.AtomicSwaps/Server/Controllers/LogsController.cs
+++ b/src/Blockcore.AtomicSwaps/Server/Controllers/LogsController.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+using Blockcore.AtomicSwaps.Server.Services;
+using Blockcore.AtomicSwaps.Shared;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Blockcore.AtomicSwaps.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class LogsController : ControllerBase
+    {
+        private readonly ILogger<LogsController> _logger;
+        private readonly ITelegramBotService _telegramBotService;
+
+        public LogsController(ILogger<LogsController> logger, ITelegramBotService telegramBotService)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _telegramBotService = telegramBotService;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> PostLog(ClientLog log)
+        {
+            // TODO: Save the client's `log` in the database
+
+            _logger.Log(log.LogLevel, log.EventId, log.Url + Environment.NewLine + log.Message);
+
+            await _telegramBotService.SendLogAsync(log);
+
+            return Ok();
+        }
+    }
+}

--- a/src/Blockcore.AtomicSwaps/Server/Program.cs
+++ b/src/Blockcore.AtomicSwaps/Server/Program.cs
@@ -1,4 +1,6 @@
+using Blockcore.AtomicSwaps.Server.Services;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,7 +9,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 builder.Services.AddSwaggerGen();
-
+builder.Services.Configure<TelegramLoggingBotOptions>(options =>builder.Configuration.GetSection("TelegramLoggingBot").Bind(options));
+builder.Services.AddSingleton<ITelegramBotService, TelegramBotService>();
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/src/Blockcore.AtomicSwaps/Server/Services/TelegramBotService.cs
+++ b/src/Blockcore.AtomicSwaps/Server/Services/TelegramBotService.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Blockcore.AtomicSwaps.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Blockcore.AtomicSwaps.Server.Services
+{
+    public class TelegramLoggingBotOptions
+    {
+        public string AccessToken { get; set; }
+        public string ChatId { get; set; }
+    }
+
+    public interface ITelegramBotService
+    {
+        Task SendLogAsync(ClientLog log);
+    }
+
+    public class TelegramBotService : ITelegramBotService
+    {
+        private readonly string _chatId;
+        private readonly TelegramBotClient _client;
+
+        public TelegramBotService(IOptions<TelegramLoggingBotOptions> options)
+        {
+            _chatId = options.Value.ChatId;
+            _client = new TelegramBotClient(options.Value.AccessToken);
+        }
+
+        public async Task SendLogAsync(ClientLog log)
+        {
+            var text = formatMessage(log);
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return;
+            }
+
+            await _client.SendTextMessageAsync(chatId: _chatId, text: text);
+           // await _client.SendTextMessageAsync(chatId: _chatId, text: text , parseMode:ParseMode.MarkdownV2);
+        }
+
+        private static string formatMessage(ClientLog log)
+        {
+            if (string.IsNullOrWhiteSpace(log.Message))
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(toEmoji(log.LogLevel))
+                .Append(" *")
+                .AppendFormat("{0:hh:mm:ss}", DateTime.Now)
+                .Append("* ")
+                .AppendLine(log.Message);
+
+            if (!string.IsNullOrWhiteSpace(log.Exception))
+            {
+                sb.AppendLine()
+                    .Append('`')
+                    .AppendLine(log.Exception)
+                    .AppendLine(log.StackTrace)
+                    .AppendLine("`")
+                    .AppendLine();
+            }
+
+            sb.Append("*Url:* ").AppendLine(log.Url);
+            return sb.ToString();
+        }
+
+        private static string toEmoji(LogLevel level) =>
+            level switch
+            {
+                LogLevel.Trace => "⬜️",
+                LogLevel.Debug => "🟦",
+                LogLevel.Information => "⬛️️️",
+                LogLevel.Warning => "🟧",
+                LogLevel.Error => "🟥",
+                LogLevel.Critical => "❌",
+                LogLevel.None => "🔳",
+                _ => throw new ArgumentOutOfRangeException(nameof(level), level, null)
+            };
+    }
+}

--- a/src/Blockcore.AtomicSwaps/Server/appsettings.json
+++ b/src/Blockcore.AtomicSwaps/Server/appsettings.json
@@ -1,9 +1,14 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*",
+    "TelegramLoggingBot": {
+        "AccessToken": "",
+        "ChatId": "" // To find the ChatId, forward a message from your private channel to the @JsonDumpBot to see the `forward_from_chat:id` number.
     }
-  },
-  "AllowedHosts": "*"
 }

--- a/src/Blockcore.AtomicSwaps/Shared/ClientLog.cs
+++ b/src/Blockcore.AtomicSwaps/Shared/ClientLog.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Logging;
+
+namespace Blockcore.AtomicSwaps.Shared
+{
+    public class ClientLog
+    {
+        public LogLevel LogLevel { get; set; }
+
+        public EventId EventId { get; set; }
+
+        public string Message { get; set; }
+
+        public string Exception { get; set; }
+
+        public string StackTrace { get; set; }
+
+        public string Url { get; set; }
+    }
+}


### PR DESCRIPTION
Whenever an exception or an error occurs on the client side, the user is informed about it with a yellow bar at the bottom of the screen; But what about the programmer?! Therefore, in this PR, we plan to log all the errors that occurred in the client side program and send them to the Telegram server. The advantage of working with Telegram is access to a server that is almost always available, and unlike the program's database, which may be the main cause at the time of an error and is unable to record the error information received from the client, such a problem can be solved with We don't have Telegram (like the famous saying: "A backup of a server that is taken on the same server is not called a backup!"). It is also very easy to check and delete the reports received, and these reports can be checked independently of the application server and through various devices such as mobile phones, tablets, etc.